### PR TITLE
[CDINFRA-193] HAProxy config refactoring

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,8 @@ _haproxy:
         - "# records -- default is only 512 bytes"
         - "accepted_payload_size 8192"
   userlists: []
+  frontends: []
+  backends: []
   proxies:
     - name: "proxy1"
       options: [ "option dontlog-normal"]

--- a/templates/etc/haproxy/__role_default_haproxy.cfg__.j2
+++ b/templates/etc/haproxy/__role_default_haproxy.cfg__.j2
@@ -56,7 +56,7 @@ listen admin
   stats show-desc instance name sidecar {{ _haproxy.instance_name }}
   stats refresh 10s
 
-{% for userlist in _haproxy.userlists %}
+{% for userlist in _haproxy.userlists | default([]) %}
 {% set groups = [] %}
 userlist {{ userlist.name }}
 {% for user in userlist.users %}
@@ -78,7 +78,7 @@ userlist {{ userlist.name }}
 
 {% endfor %}
 
-{% for p in _haproxy.proxies %}
+{% for p in _haproxy.proxies | default([]) %}
 listen {{ p.name }}
 {% for bind in p.binds %}
   bind {{ bind.ip }}:{{ bind.port }}{% if bind.accept_proxy|default(false)%} accept-proxy{%endif%}{% if bind.ssl|default(false) %} ssl crt /etc/{{ _haproxy.instance_name }}/ssl{% endif %}{% if bind.ssl_client_cert|default(false) %} verify required ca-file {{ p.intermediate_ca }} ca-verify-file {{ p.root_ca }}{% endif %}
@@ -97,4 +97,268 @@ listen {{ p.name }}
 {% endfor %}
 
 
+{% endfor %}
+
+{% for frontend in _haproxy.frontends | default([]) %}
+frontend {{ frontend.name }}
+{% if frontend.description is defined %}
+  description {{ frontend.description }}
+{% endif %}
+{% for bind in frontend.bind %}
+  bind {{ bind.listen }}{% for param in bind.param | default([]) %} {{ param }}{% endfor %}
+
+{% endfor %}
+{% if frontend.bind_process is defined %}
+  bind-process {{ frontend.bind_process | join(' ') }}
+{% endif %}
+{% if frontend.mode is defined %}
+  mode {{ frontend.mode }}
+{% endif %}
+{% if frontend.maxconn is defined %}
+  maxconn {{ frontend.maxconn }}
+{% endif %}
+{% for stick in frontend.stick | default([]) %}
+  stick-table {{ stick.table }}
+{% endfor %}
+{% for option in frontend.option | default([]) %}
+  option {{ option }}
+{% endfor %}
+{% for option in frontend.no_option | default([]) %}
+  no option {{ option }}
+{% endfor %}
+{% if frontend.logformat is defined %}
+  log-format {{ frontend.logformat }}
+{% endif %}
+{% if frontend.no_log | default(false) == true %}
+  no log
+{% endif %}
+{% for timeout in frontend.timeout | default([]) %}
+  timeout {{ timeout.type }} {{ timeout.timeout }}
+{% endfor %}
+{% for filter in frontend.filter | default([]) %}
+  filter {{ filter.name }}{% for param in filter.param | default([]) %} {{ param }}{% endfor %}
+{% endfor %}
+{% for acl in frontend.acl | default([]) %}
+  acl {{ acl.string }}
+{% endfor %}
+{% for capture in frontend.capture | default([]) %}
+  capture {{ capture.type }} {{ capture.name }} len {{ capture.length }}
+{% endfor %}
+{% for tcp_request_inspect_delay in frontend.tcp_request_inspect_delay | default([]) %}
+  tcp-request inspect-delay {{ tcp_request_inspect_delay.timeout }}
+{% endfor %}
+{% for tcp_request_connection in frontend.tcp_request_connection | default([]) %}
+  tcp-request connection {{ tcp_request_connection.action }}{% if tcp_request_connection.cond is defined %} {{ tcp_request_connection.cond }}{% endif %}
+
+{% endfor %}
+{% for tcp_request_content in frontend.tcp_request_content | default([]) %}
+  tcp-request content {{ tcp_request_content.action }}{% if tcp_request_content.cond is defined %} {{ tcp_request_content.cond }}{% endif %}
+
+{% endfor %}
+{% for tcp_request_session in frontend.tcp_request_session | default([]) %}
+  tcp-request session {{ tcp_request_session.action }}{% if tcp_request_session.cond is defined %} {{ tcp_request_session.cond }}{% endif %}
+
+{% endfor %}
+{% for http_request in frontend.http_request | default([]) %}
+  http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
+
+{% endfor %}
+{% for http_response in frontend.http_response | default([]) %}
+  http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
+
+{% endfor %}
+{% for action in ['reqadd', 'rspadd'] %}
+{% for params in frontend[action] | default([]) %}
+  {{ action }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
+
+{% endfor %}
+{% endfor %}
+{% for action in ['reqdel', 'reqidel', 'rspdel', 'rspidel'] %}
+{% for params in frontend[action] | default([]) %}
+  {{ action }} {{ params.search }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
+
+{% endfor %}
+{% endfor %}
+{% for action in ['reqrep', 'reqirep', 'rsprep', 'rspirep'] %}
+{% for params in frontend[action] | default([]) %}
+  {{ action }} {{ params.search }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
+
+{% endfor %}
+{% endfor %}
+{% for redirect in frontend.redirect | default([]) %}
+  redirect {{ redirect.string }}{% if redirect.cond is defined %} {{ redirect.cond }}{% endif %}
+
+{% endfor %}
+{% for compression in frontend.compression | default([]) %}
+  compression {{ compression.name }} {{ compression.value }}
+{% endfor %}
+{% if frontend.use_backend is defined %}
+{% if frontend.use_backend is iterable and frontend.use_backend is not string %}
+{% for use_backend in frontend.use_backend | default([]) %}
+  use_backend {{ use_backend }}
+{% endfor %}
+{% else %}
+  use_backend {{ frontend.use_backend }}
+{% endif %}
+{% endif %}
+{% if frontend.default_backend is defined %}
+  default_backend {{ frontend.default_backend }}
+{% endif %}
+{% for errorfile in frontend.errorfile | default([]) %}
+  errorfile {{ errorfile.code }} {{ errorfile.file }}
+{% endfor %}
+{% for line in frontend.raw_options | default([]) %}
+  {{ line }}
+{% endfor %}
+{% endfor %}
+
+{% for backend in _haproxy.backends | default([]) %}
+backend {{ backend.name }}
+{% if backend.description is defined %}
+  description {{ backend.description }}
+{% endif %}
+{% if backend.bind_process is defined %}
+  bind-process {{ backend.bind_process | join(' ') }}
+{% endif %}
+{% if backend.mode is defined %}
+  mode {{ backend.mode }}
+{% endif %}
+  balance {{ backend.balance }}
+{% if backend.source is defined %}
+  source {{ backend.source }}
+{% endif %}
+{% for option in backend.option | default([])%}
+  option {{ option }}
+{% endfor %}
+{% for option in backend.no_option | default([])%}
+  no option {{ option }}
+{% endfor %}
+{% if backend.http_check is defined %}
+{% if backend.http_check is string %}
+  http-check {{ backend.http_check }}
+{% else %}
+{% for http_check in backend.http_check %}
+  http-check {{ http_check }}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% if backend.cookie is defined %}
+  cookie {{ backend.cookie }}
+{% endif %}
+{% for filter in backend.filter | default([]) %}
+  filter {{ filter.name }}{% for param in filter.param | default([]) %} {{ param }}{% endfor %}
+{% endfor %}
+{% for acl in backend.acl | default([]) %}
+  acl {{ acl.string }}
+{% endfor %}
+{% for stick in backend.stick | default([]) %}
+  stick-table {{ stick.table }}
+{% if stick.stick_on is defined %}
+  stick on {{ stick.stick_on }}
+{% endif %}
+{% endfor %}
+{% for option in backend.no_option | default([]) %}
+  no option {{ option }}
+{% endfor %}
+{% if backend.no_log | default(false) == true %}
+  no log
+{% endif %}
+{% for tcp_check in backend.tcp_check | default([]) %}
+  tcp-check {{ tcp_check }}
+{% endfor %}
+{% for timeout in backend.timeout | default([]) %}
+  timeout {{ timeout.type }} {{ timeout.timeout }}
+{% endfor %}
+{% if backend.hash_type is defined %}
+  hash-type {{ backend.hash_type }}
+{% endif %}
+{% for action in ['reqadd', 'rspadd'] %}
+{% for params in backend[action] | default([]) %}
+  {{ action }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
+
+{% endfor %}
+{% endfor %}
+{% for action in ['reqdel', 'reqidel', 'rspdel', 'rspidel'] %}
+{% for params in backend[action] | default([]) %}
+  {{ action }} {{ params.search }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
+
+{% endfor %}
+{% endfor %}
+{% for action in ['reqrep', 'reqirep', 'rsprep', 'rspirep'] %}
+{% for params in backend[action] | default([]) %}
+  {{ action }} {{ params.search }} {{ params.string }}{% if params.cond is defined %} {{ params.cond }}{% endif %}
+
+{% endfor %}
+{% endfor %}
+{% if backend.stats is defined %}
+{% if backend.stats.enable is defined and backend.stats.enable | bool == true %}
+  stats enable
+  stats uri {{ backend.stats.uri | default('/') }}
+{% if backend.stats.refresh is defined %}
+  stats refresh {{ backend.stats.refresh }}
+{% endif %}
+{% if backend.stats.admin is defined %}
+  stats admin {{ backend.stats.admin }}
+{% endif %}
+{% for option in backend.stats.options | default([]) %}
+  stats {{ option }}
+{% endfor %}
+{% for auth in backend.stats.auth | default([]) %}
+  stats auth {{ auth.user }}:{{ auth.passwd }}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% for http_request in backend.http_request | default([]) %}
+  http-request {{ http_request.action }}{% if http_request.param is defined %} {{ http_request.param }}{% endif %}{% if http_request.cond is defined %} {{ http_request.cond }}{% endif %}
+
+{% endfor %}
+{% for tcp_request_inspect_delay in backend.tcp_request_inspect_delay | default([]) %}
+  tcp-request inspect-delay {{ tcp_request_inspect_delay.timeout }}
+{% endfor %}
+{% for tcp_request_content in backend.tcp_request_content | default([]) %}
+  tcp-request content {{ tcp_request_content.action }}{% if tcp_request_content.cond is defined %} {{ tcp_request_content.cond }}{% endif %}
+
+{% endfor %}
+{% for http_response in backend.http_response | default([]) %}
+  http-response {{ http_response.action }}{% if http_response.param is defined %} {{ http_response.param }}{% endif %}{% if http_response.cond is defined %} {{ http_response.cond }}{% endif %}
+
+{% endfor %}
+{% for compression in backend.compression | default([]) %}
+  compression {{ compression.name }} {{ compression.value }}
+{% endfor %}
+{% if backend.default_server_params | default([]) %}
+  default-server {% for param in backend.default_server_params | default([]) %} {{ param }}{% endfor %}
+
+{% endif %}
+{% for server in backend.server | default([]) %}
+  server {{ server.name }} {{ server.listen }}{% for param in server.param | default([]) %} {{ param }}{% endfor %}
+
+{% endfor %}
+{% for server_dynamic in backend.server_dynamic | default([]) %}
+{% for server_name in groups[server_dynamic.group] %}
+{% set server = hostvars[server_name] %}
+  server {{ server.inventory_hostname }} {% if server.ansible_host is defined %}{{ server.ansible_host }}{% else %}{{ server_name }}{% endif %}{% if server_dynamic.listen_port is defined %}:{{ server_dynamic.listen_port }}{% endif %}{% for param in server_dynamic.param | default([]) %} {{ param }}{% endfor %}
+
+{% endfor %}
+{% endfor %}
+{% if backend.server_template is defined %}
+  server-template {{ backend.server_template.name }} {{ backend.server_template.num}} {{ backend.server_template.fqdn }}{% if backend.server_template.port is defined %}:{{ backend.server_template.port }}{% endif %} {% for param in backend.server_template.param | default([]) %} {{ param }}{% endfor %}
+
+{% endif %}
+{% if backend.retry_on is defined %}
+  retry-on {% for r in backend.retry_on %}{{ r }} {% endfor %}
+
+{% endif %}
+{% if backend.retries is defined %}
+  retries {{ backend.retries }}
+{% endif %}
+{% for errorfile in backend.errorfile | default([]) %}
+  errorfile {{ errorfile.code }} {{ errorfile.file }}
+{% endfor %}
+{% for email_alert in backend.email_alert | default([]) %}
+  email-alert {{ email_alert.code }} {{ email_alert.value }}
+{% endfor %}
+{% for line in backend.raw_options | default([]) %}
+  {{ line }}
+{% endfor %}
 {% endfor %}


### PR DESCRIPTION
- Erlaubt in Zukunft die HAProxy Konfig über Variablen zu erzeugen, sodass wir nicht mehr das Jinja2 Template in den Projekten überschreiben müssen